### PR TITLE
Make trunkVLAN.py slightly more pythonic

### DIFF
--- a/depl/trunkVLAN.py
+++ b/depl/trunkVLAN.py
@@ -26,13 +26,11 @@ for vlan in vlans:
 
 # find correct servers to open VLAN trunk to
 servers = hw_mgr.list_hardware(mask=hw_mask)
-keywords = ['CONTROLLER', 'CTL', 'KVM01', 'KVM02', 'KVM001', 'KVM002', 'KVM1', 'KVM2', 'QKR', 'VYATTA', 'MGW']
+server_names = ['CONTROLLER', 'CTL', 'KVM01', 'KVM02', 'KVM001', 'KVM002', 'KVM1', 'KVM2', 'QKR', 'VYATTA', 'MGW']
 bootstrap_hosts = []
 
 for server in servers:
-    found = False
-    found = any(keyword in server['hostname'].upper() for keyword in keywords)
-    if found == True:
+    if server['hostname'].upper() in server_names:
         bootstrap_hosts.append(server)
 
 for host in bootstrap_hosts:


### PR DESCRIPTION
Makes trunkVLAN.py slightly more pythonic by ridding it of the unnecessary `any` function call. Would in theory make it faster because it would take it from O(n^2) -> O(n), but the speed increase would be negligible with such a small list. It also renames `keywords` to the more descriptive `server_names`.
